### PR TITLE
Add Automated Input Generation

### DIFF
--- a/extensions/PSInvokeBuildTask/task.ps1
+++ b/extensions/PSInvokeBuildTask/task.ps1
@@ -8,8 +8,9 @@ $Inputs = @{}
 foreach ($InputItem in $TaskJsonData.Inputs) {
     $Params = @{
         Name = $InputItem.Name
-        Require = $InputItem.required
+        Require = $InputItem.required -eq $true
         AsBool = $InputItem.type -eq 'boolean'
+        AsInt = $InputItem.options.IsInt -eq $true
     }
     $Inputs[$InputItem.Name] = Get-VstsInput -Name 'Task'
 }

--- a/extensions/PSInvokeBuildTask/task.ps1
+++ b/extensions/PSInvokeBuildTask/task.ps1
@@ -1,22 +1,15 @@
 [CmdletBinding()]
 Param()
 
-$Task = Get-VstsInput -Name 'Task' -Require
-$File = Get-VstsInput -Name 'File' -Require
-$ParameterJson = Get-VstsInput -Name 'ParameterJson'
+$TaskJsonFile = Join-Path $PSScriptRoot 'task.json'
+$TaskJsonData = Get-Content -raw $TaskJsonFile | ConvertFrom-Json
 
-'Task: {0}' -f $Task
-'File: {0}' -f $File
-'ParameterJson:'
-'---'
-$ParameterJson
-'---'
-'Env:'
-'---'
-Get-ChildItem env: | sort Name | ft Name,Value -AutoSize
-'---'
-'Variable:'
-'---'
-Get-ChildItem variable: | sort Name | ft Name,Value -AutoSize
-'---'
-'PSModulePath: {0}' -f $env:PSModulePath
+$Inputs = @{}
+foreach ($InputItem in $TaskJsonData.Inputs) {
+    $Params = @{
+        Name = $InputItem.Name
+        Require = $InputItem.required
+        AsBool = $InputItem.type -eq 'boolean'
+    }
+    $Inputs[$InputItem.Name] = Get-VstsInput -Name 'Task'
+}


### PR DESCRIPTION
Populates an $Inputs hashtable with the data from inputs as detected from the task.json. This will automatically import bools as bools. Because the current task.json does not have number input types available, importing an input as an Int requires the task.json input be defined like so:

```json
   "inputs": [
        {
            "name": "MyNumber",
            "type": "string",
            "label": "Enter a number",
            "defaultValue": "0",
            "required": true,
            "helpMarkDown": "",
            "options": {
               "IsInt": true
             }
        }
    ]
```